### PR TITLE
use plugin_basename() to set plugin $_path

### DIFF
--- a/class-gfsimplefeedaddon.php
+++ b/class-gfsimplefeedaddon.php
@@ -7,7 +7,6 @@ class GFSimpleFeedAddOn extends GFFeedAddOn {
 	protected $_version = GF_SIMPLE_FEED_ADDON_VERSION;
 	protected $_min_gravityforms_version = '1.9.16';
 	protected $_slug = 'simplefeedaddon';
-	protected $_path;
 	protected $_full_path = __FILE__;
 	protected $_title = 'Gravity Forms Simple Feed Add-On';
 	protected $_short_title = 'Simple Feed Add-On';

--- a/class-gfsimplefeedaddon.php
+++ b/class-gfsimplefeedaddon.php
@@ -7,7 +7,7 @@ class GFSimpleFeedAddOn extends GFFeedAddOn {
 	protected $_version = GF_SIMPLE_FEED_ADDON_VERSION;
 	protected $_min_gravityforms_version = '1.9.16';
 	protected $_slug = 'simplefeedaddon';
-	protected $_path = 'simplefeedaddon/simplefeedaddon.php';
+	protected $_path;
 	protected $_full_path = __FILE__;
 	protected $_title = 'Gravity Forms Simple Feed Add-On';
 	protected $_short_title = 'Simple Feed Add-On';
@@ -25,6 +25,14 @@ class GFSimpleFeedAddOn extends GFFeedAddOn {
 		}
 
 		return self::$_instance;
+	}
+	
+	/**
+	 * Initialization 
+	 */
+	public function __construct() {
+		$this->_path = plugin_basename( __FILE__ );
+		parent::__construct();
 	}
 
 	/**


### PR DESCRIPTION
The folder name of a plugin could change depending on how it is installed - using plugin_basename() ensures that $_path is always correct.
